### PR TITLE
fix: correct the method used to standardize longitude values

### DIFF
--- a/datafiles/download_US_EPA_data.sh
+++ b/datafiles/download_US_EPA_data.sh
@@ -148,11 +148,9 @@ download_US_EPA_data() {
 if [ "$SPECIES" == "all" ]; then
     # If downloading both daily and hourly data
     if [ "$FREQUENCY" == "both" ]; then
-        for FREQUENCY in "daily" "hourly"; do
-            for SPECIES in "${VALID_SPECIES[@]}"; do
-                download_US_EPA_data "$SPECIES" "$START_YEAR" "$END_YEAR" "daily"
-                download_US_EPA_data "$SPECIES" "$START_YEAR" "$END_YEAR" "hourly"
-            done
+        for SPECIES in "${VALID_SPECIES[@]}"; do
+            download_US_EPA_data "$SPECIES" "$START_YEAR" "$END_YEAR" "daily"
+            download_US_EPA_data "$SPECIES" "$START_YEAR" "$END_YEAR" "hourly"
         done
     else
         for SPECIES in "${VALID_SPECIES[@]}"; do
@@ -164,7 +162,8 @@ else
     if [ "$FREQUENCY" == "both" ]; then
         download_US_EPA_data "$SPECIES" "$START_YEAR" "$END_YEAR" "daily"
         download_US_EPA_data "$SPECIES" "$START_YEAR" "$END_YEAR" "hourly"
+    else
+        # Otherwise, just download for the specified species
+        download_US_EPA_data "$SPECIES" "$START_YEAR" "$END_YEAR" "$FREQUENCY"
     fi
-    # Otherwise, just download for the specified species
-    download_US_EPA_data "$SPECIES" "$START_YEAR" "$END_YEAR" "$FREQUENCY"
 fi

--- a/datafiles/download_US_EPA_data.sh
+++ b/datafiles/download_US_EPA_data.sh
@@ -7,8 +7,8 @@
 
 # Takes in optional arguments:
 #	$ bash download_US_EPA_data.sh -s <species>         Default: NO2
-#                                  -b <begin_year>      Default: 2005
-#                                  -e <end_year>        Default: 2020
+#                                  -b <begin_year>      Default: 1980
+#                                  -e <end_year>        Default: 2024
 #                                  -f <frequency>       Default: daily
 
 # Having a ":" after a flag means an option is required to invoke that flag
@@ -23,19 +23,24 @@ do
 	esac
 done
 
+VALID_SPECIES=("O3" "SO2" "CO" "NO2" 
+               "PM25FRM" "PM25nFRM" "PM10" "PMc" 
+               "PM25SPEC" "PM10SPEC" "WIND" "TEMP" 
+               "PRESS" "RH_and_DP" "HAPs" "VOCs" 
+               "NOX" "LEAD")
+
 # Check to see if input arguments are set, otherwise set defaults
 if [ -z "$SPECIES" ]; then
-    SPECIES="NO2"
+    SPECIES="all"
 else
     # Check to make sure the species are valid
-    VALID_SPECIES=("O3" "SO2" "CO" "NO2")
-    if [[ ! " ${VALID_SPECIES[@]} " =~ " ${SPECIES} " ]]; then
-        echo "Invalid species, $SPECIES. Valid options are: ${VALID_SPECIES[*]}"
+    if [[ ! " ${VALID_SPECIES[@]} " =~ " ${SPECIES} " ]] && [ ! "${SPECIES}" == "all" ]; then
+        echo "Invalid species, $SPECIES. Valid options are: ${VALID_SPECIES[*]} or all."
         exit 1
     fi
 fi
 if [ -z "$START_YEAR" ]; then
-    START_YEAR=2005
+    START_YEAR=1980
 else
     # Check to make sure the start year is between 1980-2024
     if [[ ! "$START_YEAR" =~ ^[0-9]{4}$ ]] || [ "$START_YEAR" -lt 1980 ] || [ "$START_YEAR" -gt 2024 ]; then
@@ -44,7 +49,7 @@ else
     fi
 fi
 if [ -z "$END_YEAR" ]; then
-    END_YEAR=2020
+    END_YEAR=2024
 else
     # Check to make sure the end year is between 1980-2024
     if [[ ! "$END_YEAR" =~ ^[0-9]{4}$ ]] || [ "$END_YEAR" -lt 1980 ] || [ "$END_YEAR" -gt 2024 ]; then
@@ -53,49 +58,113 @@ else
     fi
 fi
 if [ -z "$FREQUENCY" ]; then
-    FREQUENCY="daily"
+    FREQUENCY="both"  # Default to both daily and hourly
 else
     # Check to make sure the frequency is valid
-    if [[ "$FREQUENCY" != "daily" && "$FREQUENCY" != "hourly" ]]; then
-        echo "Invalid frequency, $FREQUENCY. Valid options are: daily, hourly"
+    if [[ "$FREQUENCY" != "daily" && "$FREQUENCY" != "hourly" && "$FREQUENCY" != "both" ]]; then
+        echo "Invalid frequency, $FREQUENCY. Valid options are: daily, hourly, or both."
         exit 1
     fi
 fi
 
-echo "Downloading US EPA data for species: $SPECIES from $START_YEAR to $END_YEAR"
-
-# Create the data directory if it doesn't exist
+# Set the local directory in which the data will be stored
 DATA_DIR="/data/high_res/US_EPA"
-mkdir -p "$DATA_DIR"
-# Create the species directory if it doesn't exist
-SPECIES_DIR="$DATA_DIR/$SPECIES"
-mkdir -p "$SPECIES_DIR"
 
-# Get the ID number based on species
-case "$SPECIES" in
-    "O3") ID="44201" ;;
-    "SO2") ID="42401" ;;
-    "CO") ID="42101" ;;
-    "NO2") ID="42602" ;;
-    *) echo "Invalid species: $SPECIES"; exit 1 ;;
-esac
+# Function to download and unzip one set of US EPA data
+download_US_EPA_data() {
+    local SPECIES=$1
+    local START_YEAR=$2
+    local END_YEAR=$3
+    local FREQUENCY=$4
 
-# Loop through the years and download the data
-for YEAR in $(seq $START_YEAR $END_YEAR); do
-    # Construct the URL
-    URL="https://aqs.epa.gov/aqsweb/airdata/${FREQUENCY}_${ID}_${YEAR}.zip"
-    # Download the file
-    wget -q --show-progress "$URL" -O "$SPECIES_DIR/${FREQUENCY}_${ID}_${YEAR}.zip"
-    
-    # Check if the download was successful
-    if [ $? -ne 0 ]; then
-        echo "Failed to download data for year: $YEAR"
-        continue
+    echo "Downloading $FREQUENCY US EPA data for species: $SPECIES from $START_YEAR to $END_YEAR"
+
+    # Create the data directory if it doesn't exist
+    mkdir -p "$DATA_DIR"
+    # Create the species directory if it doesn't exist
+    SPECIES_DIR="$DATA_DIR/$SPECIES"
+    mkdir -p "$SPECIES_DIR"
+    # Create the freqency directory if it doesn't exist
+    FREQUENCY_DIR="$SPECIES_DIR/${FREQUENCY}_${SPECIES}"
+    mkdir -p "$FREQUENCY_DIR"
+
+    # Get the ID number based on species
+    case "$SPECIES" in
+        # Criteria gases
+        "O3") ID="44201" ;;
+        "SO2") ID="42401" ;;
+        "CO") ID="42101" ;;
+        "NO2") ID="42602" ;;
+        # Particulate matter
+        "PM25FRM") ID="88101" ;;
+        "PM25nFRM") ID="88502" ;;
+        "PM10") ID="81102" ;;
+        "PMc") ID="86101" ;;
+        "PM25SPEC") ID="SPEC" ;;
+        "PM10SPEC") ID="PM10SPEC" ;;
+        # Meteorological
+        "WIND") ID="WIND" ;;
+        "TEMP") ID="TEMP" ;;
+        "PRESS") ID="PRESS" ;;
+        "RH_and_DP") ID="RH_DP" ;;
+        # Toxics, Percoursors, and Lead
+        "HAPs") ID="HAPS" ;;
+        "VOCs") ID="VOCS" ;;
+        "NOX") ID="NONOxNOy" ;;
+        "LEAD") ID="LEAD" ;;
+        *) echo "Invalid species: $SPECIES"; exit 1 ;;
+    esac
+
+    # Loop through the years and download the data
+    for YEAR in $(seq $START_YEAR $END_YEAR); do
+        # Construct the file name
+        FILENAME="${FREQUENCY}_${ID}_${YEAR}"
+        # Check if the file already exists locally
+        if [ -f "$FREQUENCY_DIR/$FILENAME.csv" ]; then
+            echo "File $FILENAME already exists, skipping download."
+            continue
+        else
+            # Construct the URL
+            URL="https://aqs.epa.gov/aqsweb/airdata/${FILENAME}.zip"
+            # Download the file
+            wget -q --show-progress "$URL" -O "$FREQUENCY_DIR/${FILENAME}.zip"
+            
+            # Check if the download was successful
+            if [ $? -ne 0 ]; then
+                echo "Failed to download data for year: $YEAR"
+                continue
+            fi
+            
+            # Unzip the file
+            unzip -o "$FREQUENCY_DIR/${FILENAME}.zip" -d "$FREQUENCY_DIR"
+            
+            # Remove the zip file after extraction
+            rm "$FREQUENCY_DIR/${FILENAME}.zip"
+        fi
+    done
+}
+
+# If downloading for all species, loop through each species
+if [ "$SPECIES" == "all" ]; then
+    # If downloading both daily and hourly data
+    if [ "$FREQUENCY" == "both" ]; then
+        for FREQUENCY in "daily" "hourly"; do
+            for SPECIES in "${VALID_SPECIES[@]}"; do
+                download_US_EPA_data "$SPECIES" "$START_YEAR" "$END_YEAR" "daily"
+                download_US_EPA_data "$SPECIES" "$START_YEAR" "$END_YEAR" "hourly"
+            done
+        done
+    else
+        for SPECIES in "${VALID_SPECIES[@]}"; do
+            download_US_EPA_data "$SPECIES" "$START_YEAR" "$END_YEAR" "$FREQUENCY"
+        done
     fi
-    
-    # Unzip the file
-    unzip -o "$SPECIES_DIR/${FREQUENCY}_${ID}_${YEAR}.zip" -d "$SPECIES_DIR"
-    
-    # Remove the zip file after extraction
-    rm "$SPECIES_DIR/${FREQUENCY}_${ID}_${YEAR}.zip"
-done
+else
+    # If downloading both daily and hourly data
+    if [ "$FREQUENCY" == "both" ]; then
+        download_US_EPA_data "$SPECIES" "$START_YEAR" "$END_YEAR" "daily"
+        download_US_EPA_data "$SPECIES" "$START_YEAR" "$END_YEAR" "hourly"
+    fi
+    # Otherwise, just download for the specified species
+    download_US_EPA_data "$SPECIES" "$START_YEAR" "$END_YEAR" "$FREQUENCY"
+fi

--- a/src/unox/data.py
+++ b/src/unox/data.py
@@ -377,6 +377,43 @@ def shift_lon(
     else:
         raise ValueError("PM_centered must be True or False.")
 
+def shift_lon_arr(
+    lon_array,
+    PM_centered=True
+    ):
+    """
+    Shift the given array of longitude values between ranges [0, 360] and [-180, 180].
+
+    Map the `shift_lon` function to shift each value in the array.
+
+    Parameters
+    ----------
+    lon_array : numpy.ndarray or xarray.DataArray
+        The array of longitude values to shift.
+    PM_centered : bool, optional
+        If True, shift the longitude value from the range [0, 360] to [-180, 180].
+        If False, shift from [-180, 180] to [0, 360]. Defaults to True.
+
+    Returns
+    -------
+    numpy.ndarray or xarray.DataArray
+        The shifted longitude values in the range [-180, 180].
+
+    Examples
+    --------
+    >>> lon_array = np.array([0, 90, 180, 270, 360])
+    >>> shifted_lon = shift_lon_arr(lon_array)
+    array([0, 90, 180, -90, 0])
+    """
+    # Ensure the input is a numpy array or xarray DataArray
+    if not isinstance(lon_array, (np.ndarray, xr.DataArray)):
+        raise TypeError("Input must be a numpy.ndarray or xarray.DataArray.")
+    
+    # Map the shift_lon function to each element in the array
+    shifted_lon = np.vectorize(shift_lon, excluded={1})(lon_array, PM_centered)
+    
+    return shifted_lon
+
 def get_vminmax(arrays):
     """Get the minimum and maximum values across the given arrays.
 

--- a/src/unox/data.py
+++ b/src/unox/data.py
@@ -102,7 +102,7 @@ def get_lats_lons(xr_dataset,
     # Verify the latitude and longitude values
     map(verify_lat, lats)
     if shift_lons:
-        lons = np.array(list(map(shift_lon, lons)))
+        lons = np.array(shift_lon_arr(lons))
     map(verify_lon, lons)
     return lats, lons
 
@@ -348,6 +348,37 @@ def shift_lon(lon_value):
     if lon_value < 0 or lon_value > 360:
         raise ValueError(f"Longitude value must be in the range [0, 360], lon_value = {lon_value}.")
     return lon_value - 180
+
+def shift_lon_arr(lon_array):
+    """
+    Shift the given array of longitude values from the range [0, 360] to [-180, 180].
+
+    Map the `shift_lon` function to shift each value in the array.
+
+    Parameters
+    ----------
+    lon_array : numpy.ndarray or xarray.DataArray
+        The array of longitude values to shift.
+
+    Returns
+    -------
+    numpy.ndarray or xarray.DataArray
+        The shifted longitude values in the range [-180, 180].
+
+    Examples
+    --------
+    >>> lon_array = np.array([0, 90, 180, 270, 360])
+    >>> shifted_lon = shift_lon_arr(lon_array)
+    array([-180,  -90,    0,   90,  180])
+    """
+    # Ensure the input is a numpy array or xarray DataArray
+    if not isinstance(lon_array, (np.ndarray, xr.DataArray)):
+        raise TypeError("Input must be a numpy.ndarray or xarray.DataArray.")
+    
+    # Map the shift_lon function to each element in the array
+    shifted_lon = np.vectorize(shift_lon)(lon_array)
+    
+    return shifted_lon
 
 def get_vminmax(arrays):
     """Get the minimum and maximum values across the given arrays.

--- a/src/unox/data.py
+++ b/src/unox/data.py
@@ -48,6 +48,9 @@ def get_extent(xr_dataset=None,
         # Find the min and max lat and lon values
         lat_min = np.unique(np.min(lats))[0]
         lat_max = np.unique(np.max(lats))[0]
+        # Shift the longitude values if specified
+        if shift_lons:
+            lons = shift_lon_arr(lons)
         lon_min = np.unique(np.min(lons))[0]
         lon_max = np.unique(np.max(lons))[0]
     else:
@@ -57,15 +60,16 @@ def get_extent(xr_dataset=None,
         # Use np.unique to ensure that the values are unique and take only the first value
         lat_min = np.unique(xr_dataset.lat.min().values)[0]
         lat_max = np.unique(xr_dataset.lat.max().values)[0]
-        lon_min = np.unique(xr_dataset.lon.min().values)[0]
-        lon_max = np.unique(xr_dataset.lon.max().values)[0]
+        # Shift the longitude values if specified
+        if shift_lons:
+            lons = shift_lon_arr(xr_dataset.lon.values)
+        else:
+            lons = xr_dataset.lon.values
+        lon_min = np.unique(lons.min())[0]
+        lon_max = np.unique(lons.max())[0]
     # Verify that latitude values are in the range [-90, 90]
     lat_max = verify_lat(lat_max)
     lat_min = verify_lat(lat_min)
-    # Verify that longitude values are in the range [-180, 180]
-    if shift_lons:
-        lon_min = shift_lon(lon_min)
-        lon_max = shift_lon(lon_max)
     lon_max = verify_lon(lon_max)
     lon_min = verify_lon(lon_min)
     # Return the extent as a tuple
@@ -317,17 +321,26 @@ def verify_lon(lon_val):
         raise ValueError(f"Longitude value must be in the range [-180, 180], lon_val = {lon_val}.")
     return lon_val
 
-def shift_lon(lon_value):
-    """Shift the given longitude value from the range [0, 360] to [-180, 180].
+def shift_lon(
+    lon_value,
+    PM_centered=True
+    ):
+    """Shift the given longitude value between ranges [0, 360] and [-180, 180].
 
-    If the given longitude value is within the range [0, 360],
-    return that value shifted to the range [-180, 180].
-    Otherwise, raise a ValueError.
+    If the Prime Meridian is centered and the longitude value is in the range [0, 360],
+    shift it to the range [-180, 180]. If the Prime Meridian is not centered (i.e. the
+    International Date Line is centered) and the longitude value is in the range 
+    [-180, 180], shift it to the range [0, 360]. Otherwise, return the same value.
+    If the longitude value is not a number or is NaN, or is outside the relevant range
+    for the specified PM_centered, raise a ValueError.
 
     Parameters
     ----------
     lon_value : float
         The longitude value to shift.
+    PM_centered : bool, optional
+        If True, shift the longitude value from the range [0, 360] to [-180, 180].
+        If False, shift from [-180, 180] to [0, 360]. Defaults to True.
 
     Returns
     -------
@@ -336,49 +349,33 @@ def shift_lon(lon_value):
 
     Examples
     --------
-    >>> lon_value = shift_lon(45.0)
-    -315.0
-    >>> lon_value = shift_lon(-200.0)
-    ValueError: Longitude value must be in the range [0, 360].
+    >>> lon_value = shift_lon(45.0, PM_centered=True)
+    45.0
+    >>> lon_value = shift_lon(270.0, PM_centered=True)
+    -90.0
+    >>> lon_value = shift_lon(-70.0, PM_centered=False)
+    290.0
+    >>> lon_value = shift_lon(200.0, PM_centered=False)
+    200.0
     """
     if not verify_number(lon_value):
         raise ValueError("Longitude value must be a number.")
     if np.isnan(lon_value):
         raise ValueError("Longitude value must not be NaN.")
-    if lon_value < 0 or lon_value > 360:
-        raise ValueError(f"Longitude value must be in the range [0, 360], lon_value = {lon_value}.")
-    return lon_value - 180
-
-def shift_lon_arr(lon_array):
-    """
-    Shift the given array of longitude values from the range [0, 360] to [-180, 180].
-
-    Map the `shift_lon` function to shift each value in the array.
-
-    Parameters
-    ----------
-    lon_array : numpy.ndarray or xarray.DataArray
-        The array of longitude values to shift.
-
-    Returns
-    -------
-    numpy.ndarray or xarray.DataArray
-        The shifted longitude values in the range [-180, 180].
-
-    Examples
-    --------
-    >>> lon_array = np.array([0, 90, 180, 270, 360])
-    >>> shifted_lon = shift_lon_arr(lon_array)
-    array([-180,  -90,    0,   90,  180])
-    """
-    # Ensure the input is a numpy array or xarray DataArray
-    if not isinstance(lon_array, (np.ndarray, xr.DataArray)):
-        raise TypeError("Input must be a numpy.ndarray or xarray.DataArray.")
-    
-    # Map the shift_lon function to each element in the array
-    shifted_lon = np.vectorize(shift_lon)(lon_array)
-    
-    return shifted_lon
+    # If using PM-centered convention
+    if PM_centered==True:
+        # Check if the value is in the range [0, 360]
+        if lon_value >= 0 and lon_value <= 360:
+            # Shift to [-180, 180]
+            return (lon_value + 180) % 360 - 180
+    # If using IDL-centered convention
+    elif PM_centered==False:
+        # Check if the value is in the range [-180, 180]
+        if lon_value >= -180 and lon_value <= 180:
+            # Shift to [0, 360]
+            return (lon_value + 360) % 360
+    else:
+        raise ValueError("PM_centered must be True or False.")
 
 def get_vminmax(arrays):
     """Get the minimum and maximum values across the given arrays.

--- a/src/unox/input.py
+++ b/src/unox/input.py
@@ -81,10 +81,14 @@ def make_y_input_file(year,
     if not isinstance(output_dir, type(None)):
         # Assemble the file path
         output_filepath = os.path.join(output_dir, f"stage1/y/Y_{year}.npy")
+        # Make sure the output directory exists
+        unox.make_file_path(output_filepath)
         np.save(output_filepath, y_data)
         if year > stage_2_cutoff:
             # Save in stage 2 for years later than specified
             output_filepath_stage2 = os.path.join(output_dir, f"stage2/y/Y_{year}.npy")
+            # Make sure the output directory exists
+            unox.make_file_path(output_filepath)
             np.save(output_filepath_stage2, y_data)
         # Output message
         print(f"Created Y input file for {var} in {year}, saved to {output_filepath}")
@@ -226,6 +230,8 @@ def make_x_input_file(year,
     if not isinstance(output_dir, type(None)):
         # Assemble the file path
         output_filepath = os.path.join(output_dir, f'stage{stage}/x/X_{year}.npy')
+        # Make sure the output directory exists
+        unox.make_file_path(output_filepath)
         np.save(output_filepath, xnp)
         # Output message
         print(f"Created X input file for stage {stage} in {year}, saved to {output_filepath}")

--- a/src/unox/input.py
+++ b/src/unox/input.py
@@ -124,7 +124,7 @@ def make_x_input_file(year,
         The stage of the model (1 or 2) this will be input for.
     data_dir : str, optional
         Directory where the NOx data are stored. 
-        Default is '/data/high_res/emacdonald/unet/datafiles/t106'.
+        Default is '/data/high_res/emacdonald/unet/datafiles/'.
     chemra_path : str, optional
         Path to the chemical reanalysis data files. 
         Default is 'TROPESS/TROPESS_reanalysis_2hr_no2_sfc_'.
@@ -151,10 +151,11 @@ def make_x_input_file(year,
     # Verify the path
     chemra_filepath = unox.verify_path(chemra_filepath)
     # Load chemical reanalysis data
-    chemra = xr.load_dataset(chemra_filepath)
+    # chemra = xr.load_dataset(chemra_filepath)
+    chemra = xr.open_dataset(chemra_filepath)
     # Change longitude coordinate convention to match other data
-    chemra.coords['lon'] = (chemra.coords['lon'] + 180) % 360 - 180  
-    # chemra.coords['lon'] = udata.shift_lon(chemra.coords['lon'])  
+    # chemra.coords['lon'] = (chemra.coords['lon'] + 180) % 360 - 180
+    chemra.coords['lon'] = udata.shift_lon_arr(chemra.coords['lon'])
     # Resample and rescale
     chemra = chemra.resample(time='d').mean() / scale_factors['chemra']
     # Find the number of days in the year
@@ -175,7 +176,7 @@ def make_x_input_file(year,
     
     # Interpolate to latitude and longitude grid
     lats, lons = unox.load_lats_lons()
-    chemra = chemra.interp(lat=lats, lon=lons)
+    chemra = chemra.interp(lat=lats, lon=lons, method='slinear')
     
     # Start a list to hold datasets
     datasets = []

--- a/src/unox/plotting.py
+++ b/src/unox/plotting.py
@@ -130,7 +130,7 @@ def plot_nc_map(xr_dataset='../datafiles/nox_2019_t106_US.nc',
 
     Parameters
     ----------
-    xr_dataset : str
+    xr_dataset : str or xarray.Dataset or xarray.DataArray
         Path to the netCDF data file.
     var : str
         The name of the variable to plot from the netCDF file.
@@ -156,7 +156,9 @@ def plot_nc_map(xr_dataset='../datafiles/nox_2019_t106_US.nc',
     
     Examples
     --------
-    >>> fig = plot_nc_map(xr_dataset='../datafiles/nox_2019_t106_US.nc')
+    >>> import xarray as xr
+    >>> this_dataset = xr.open_dataset('../datafiles/nox_2019_t106_US.nc')
+    >>> fig = plot_nc_map(xr_dataset=this_dataset)
     """
     # Check if xr_dataset is a file path or an xarray object
     if isinstance(xr_dataset, str):

--- a/src/unox/unox.py
+++ b/src/unox/unox.py
@@ -73,6 +73,32 @@ def verify_path(path):
     else:
         return path
 
+def remove_non_empty_directory(base_dir):
+    """Remove a non-empty directory and all its contents.
+
+    This function will recursively delete all files and directories in the given path.
+
+    Parameters
+    ----------
+    base_dir : str
+        Relative path to the directory to be removed.
+    """
+    # Verify the path
+    top = verify_path(base_dir)
+    # Check if the path is a directory
+    if not os.path.isdir(top):
+        raise ValueError(f"Path {top} is not a directory.")
+    # Recursively remove all files and directories in the given path
+    for root, dirs, files in os.walk(top, topdown=False):
+        for name in files:
+            print(f'Removing file: {os.path.join(root, name)}')
+            os.remove(os.path.join(root, name))
+        for name in dirs:
+            print(f'Removing directory: {os.path.join(root, name)}')
+            os.rmdir(os.path.join(root, name))
+    # Finally remove the top directory itself
+    os.rmdir(top)  
+
 def show_available_data(path='original_sample_data/', verb=False):
     """Print a list of available data in the given directory.
     

--- a/src/unox/unox.py
+++ b/src/unox/unox.py
@@ -73,6 +73,40 @@ def verify_path(path):
     else:
         return path
 
+def make_file_path(path):
+    """Create a file path.
+
+    If the given path doesn't exist, create the specified directory structure.
+
+    Parameters
+    ----------
+    path : str
+        Relative path to make.
+
+    Returns
+    -------
+    path : str
+        The verified path to the data files.
+
+    Examples
+    --------
+    >>> make_file_path('datafiles/some/more/data/a_file.txt')
+    'datafiles/some/more/data/'
+    """
+    # Verify the path
+    try:
+        path = verify_path(os.path.dirname(path))
+    except FileNotFoundError:
+        # If the path doesn't exist, create it
+        pass
+    if not os.path.exists(os.path.dirname(path)):
+        # Use the `exist_ok=True` argument to avoid raising an error 
+        # if the path (or some of the path) already exists
+        os.makedirs(os.path.dirname(path), exist_ok=True)
+    # Verify the path
+    path = verify_path(os.path.dirname(path))
+    return path
+
 def remove_non_empty_directory(base_dir):
     """Remove a non-empty directory and all its contents.
 

--- a/src/unox/unox.py
+++ b/src/unox/unox.py
@@ -57,6 +57,9 @@ def verify_path(path):
     --------
     >>> verify_path()
     """
+    # Check if the path is a string
+    if not isinstance(path, str):
+        raise TypeError("Path must be a string.")
     if not os.path.exists(path):
         path = '..' + path
         if not os.path.exists(path):

--- a/tests/test_data.py
+++ b/tests/test_data.py
@@ -158,7 +158,7 @@ def test_shift_lon():
     # Create a sample array of longitude values to shift
     input = np.array([0, 45.3, 200, 360])
     expected = np.array([-180, -134.7, 20, 180])
-    actual = np.array(list(map(udata.shift_lon, input)))
+    actual = np.array(udata.shift_lon_arr(input))
     assert np.array_equal(actual, expected), f"Expected {expected}, but shift_lon gave {actual}"
     # Test with invalid values
     invalid_values = [np.nan, '45', None]

--- a/tests/test_data.py
+++ b/tests/test_data.py
@@ -29,12 +29,14 @@ def test_get_extent(xr_dataset=xr.open_dataset('datafiles/nox_2019_t106_US.nc'))
     expected = (-90.0, 90.0, -180.0, 180.0)
     actual = udata.get_extent(lats=lats, lons=lons)
     assert actual == expected, f"Expected extent {expected} does not match actual extent {actual}"
+    # Select a tolerance for comparisons
+    selected_tol = 1e-15
     # Test shifting longitudes
     lats = np.array([-90, -45, 45, 90])
-    lons = np.array([0, 45.3, 200, 360])
-    expected = (-90.0, 90.0, -180.0, 180.0)
+    lons = np.array([0, 179, 180, 360])
+    expected = (-90.0, 90.0, -180.0, 179.0)
     actual = udata.get_extent(lats=lats, lons=lons, shift_lons=True)
-    assert actual == expected, f"Expected extent {expected} does not match actual extent {actual}"
+    assert np.allclose(expected, actual, atol=selected_tol, rtol=selected_tol), f"Expected extent {expected} does not match actual extent {actual}"
 
 def test_get_lats_lons(path='datafiles/TROPESS_reanalysis_mon_emi_nox_anth_2021.nc'):
     """Test the get_lats_lons function."""
@@ -155,12 +157,21 @@ def test_verify_lon():
 
 def test_shift_lon():
     """Test the shift_lon function."""
+    # Select a tolerance for comparisons
+    selected_tol = 1e-15
+    # Test the Prime Meridian centered shift
     # Create a sample array of longitude values to shift
-    input = np.array([0, 45.3, 200, 360])
-    expected = np.array([-180, -134.7, 20, 180])
-    actual = np.array(udata.shift_lon_arr(input))
-    assert np.array_equal(actual, expected), f"Expected {expected}, but shift_lon gave {actual}"
-    # Test with invalid values
+    input = np.array([0, 45.3, 200, 359])
+    expected = np.array([0, 45.3, -160.0, -1.0])
+    actual = udata.shift_lon_arr(input, PM_centered=True)
+    assert np.allclose(actual, expected, atol=selected_tol, rtol=selected_tol), f"Expected {expected}, but shift_lon gave {actual}"
+    # Test the International Date Line centered shift
+    # Create a sample array of longitude values to shift
+    input = np.array([0, 45.3, -57.5, -179])
+    expected = np.array([0, 45.3, 302.5, 181.0])
+    actual = np.array(udata.shift_lon_arr(input, PM_centered=False))
+    assert np.allclose(actual, expected, atol=selected_tol, rtol=selected_tol), f"Expected {expected}, but shift_lon gave {actual}"
+    # Test with invalid longitudes
     invalid_values = [np.nan, '45', None]
     for val in invalid_values:
         try:
@@ -169,6 +180,13 @@ def test_shift_lon():
             assert True, f"shift_lon raised an exception on invalid value {val}: {e}"
         else:
             assert False, f"shift_lon did not raise an exception on invalid value {val}"
+    # Test with invalid PM_centered argument
+    try:
+        udata.shift_lon_arr(input, PM_centered='invalid')
+    except ValueError as e:
+        assert True, f"shift_lon raised an exception on invalid PM_centered argument: {e}"
+    else:
+        assert False, "shift_lon did not raise an exception on invalid PM_centered argument"
 
 def test_get_vminmax():
     """Test the get_vminmax function."""

--- a/tests/test_data.py
+++ b/tests/test_data.py
@@ -2,6 +2,7 @@ from unox import data as udata
 import xarray as xr
 import numpy as np
 import os
+import pytest
 
 minimal_xr = xr.DataArray(
         data=[[[1], [2]], [[3], [4]]],
@@ -265,6 +266,7 @@ def test_get_max_abs_val():
     else:
         assert False, f"get_max_abs_val did not raise an exception on invalid input: {invalid_values}"
 
+@pytest.mark.filterwarnings("ignore:loadtxt", "ignore:genfromtxt")
 def test_verify_npy():
     """Test the verify_npy function."""
     
@@ -333,6 +335,14 @@ def test_verify_npy():
         assert True, f"verify_npy raised an exception on invalid input: {e}"
     else:
         assert False, f"verify_npy did not raise an exception on invalid input: {path}"
+    
+    # Clean up the test directory
+    if os.path.exists("tests/arrays"):
+        for file in os.listdir("tests/arrays"):
+            file_path = os.path.join("tests/arrays", file)
+            if os.path.isfile(file_path):
+                os.remove(file_path)
+        os.rmdir("tests/arrays")
 
 def test_get_num_from_string():
     """Test the get_num_from_string function."""

--- a/tests/test_unox.py
+++ b/tests/test_unox.py
@@ -25,6 +25,35 @@ def test_verify_path():
     else:
         assert False, f"verify_path did not raise an exception on invalid path {invalid_path}"
 
+def test_make_file_path():
+    """Test the make_file_path function."""
+    # Test with valid input
+    valid_path = 'test_make_file_path/path/to/file.txt'
+    actual = unox.make_file_path(valid_path)
+    expected = 'test_make_file_path/path/to'
+    assert actual == expected, f"Expected {expected}, but got {actual}"
+    # Delete the created directory for cleanup
+    base_dir = valid_path.split('/')[0]
+    unox.remove_non_empty_directory(base_dir)
+    # Test with valid input that already exists
+    # Remove everything after the second to last `/` in the valid path
+    partial_path = '/'.join(valid_path.split('/')[:-2])
+    print(f"Partial path: {partial_path}")
+    print(f"Valid path: {valid_path}")
+    os.makedirs(partial_path)
+    actual = unox.make_file_path(valid_path)
+    assert actual == expected, f"Expected {expected}, but got {actual}"
+    # Delete the created directory for cleanup
+    unox.remove_non_empty_directory(base_dir)
+    # Test with invalid input
+    invalid_path = 12345
+    try:
+        unox.make_file_path(invalid_path)
+    except (TypeError) as e:
+        assert True, f"make_file_path raised an exception on invalid input: {e}"
+    else:
+        assert False, f"make_file_path did not raise an exception on invalid input {invalid_path}"
+
 def test_remove_non_empty_directory():
     """Test the remove_non_empty_directory function."""
     # Create a temporary directory with some files and subdirectories

--- a/tests/test_unox.py
+++ b/tests/test_unox.py
@@ -25,6 +25,31 @@ def test_verify_path():
     else:
         assert False, f"verify_path did not raise an exception on invalid path {invalid_path}"
 
+def test_remove_non_empty_directory():
+    """Test the remove_non_empty_directory function."""
+    # Create a temporary directory with some files and subdirectories
+    temp_dir = 'test_remove_non_empty_directory'
+    os.makedirs(temp_dir, exist_ok=True)
+    with open(os.path.join(temp_dir, 'file1.txt'), 'w') as f:
+        f.write('This is a test file.')
+    os.makedirs(os.path.join(temp_dir, 'subdir'), exist_ok=True)
+    with open(os.path.join(temp_dir, 'subdir', 'file2.txt'), 'w') as f:
+        f.write('This is another test file.')
+    
+    # Remove the non-empty directory
+    unox.remove_non_empty_directory(temp_dir)
+    
+    # Check if the directory has been removed
+    assert not os.path.exists(temp_dir), f"Directory {temp_dir} was not removed."
+    
+    # Test with a non-directory path
+    try:
+        unox.remove_non_empty_directory('file1.txt')
+    except FileNotFoundError as e:
+        assert True, f"remove_non_empty_directory raised an exception on non-directory path: {e}"
+    else:
+        assert False, "remove_non_empty_directory did not raise an exception on non-directory path."
+
 def test_show_available_data():
     """Test the show_available_data function and,
     as a result, also test the recursive_paths function."""

--- a/tests/test_unox.py
+++ b/tests/test_unox.py
@@ -1,17 +1,26 @@
 from unox import unox
+import os
 
 def test_verify_path():
     """Test the verify_path function."""
-    # Test with a valid path
+    # Test with valid path
     valid_path = 'original_sample_data/stage1/x/X_2005.npy'
     actual = unox.verify_path(valid_path)
     print(f"Actual path: {actual}")
     assert type(unox.verify_path(valid_path)) == type('str'), f"verify_path failed on valid path: {valid_path}"
-    # Test with an invalid path
+    # Test with invalid path
     invalid_path = 'invalid/path/to/file.npy'
     try:
         unox.verify_path(invalid_path)
     except (FileNotFoundError) as e:
+        assert True, f"verify_path raised an exception on invalid path: {e}"
+    else:
+        assert False, f"verify_path did not raise an exception on invalid path {invalid_path}"
+    # Test with invalid path
+    invalid_path = 12345
+    try:
+        unox.verify_path(invalid_path)
+    except (TypeError) as e:
         assert True, f"verify_path raised an exception on invalid path: {e}"
     else:
         assert False, f"verify_path did not raise an exception on invalid path {invalid_path}"


### PR DESCRIPTION
Fix the shift_lon() function to correctly reformat longitude values from being (0, 360) to (-180, 180). Confirm a small shift in longitude is not the cause for discrepancies between re-generated stage 1 x input files and those which were present when I took over the project.